### PR TITLE
Corrigir bug da ordenacao das datas

### DIFF
--- a/macroChallengeApp/macroChallengeApp/Flows/Current/ViewController/MyTripViewController.swift
+++ b/macroChallengeApp/macroChallengeApp/Flows/Current/ViewController/MyTripViewController.swift
@@ -82,7 +82,7 @@ class MyTripViewController: UIViewController, NSFetchedResultsControllerDelegate
     }
     func getAllDays() {
         if var newDays = roadmap.day?.allObjects as? [DayLocal] {
-            newDays.sort { $0.date! < $1.date! }
+            newDays.sort { $0.id < $1.id }
             self.days = newDays
         }
         for index in 0..<days.count where days[index].isSelected == true {


### PR DESCRIPTION
### Qual é o propósito do PR? 
* Corrigir bug da ordenacao das datas quando a viagem começa em um mês e termina no outro ( exemplo: inicio 30/11 e final 3/12) 
### CheckList
- [x] Update from dev
- [x] Corrigiu warnings do swiftLint e padrões de projeto que seu projeto gerou
- [x] Adicionou uma issue para o seu PR
- [x] Configurou a issue na board do projeto

